### PR TITLE
Feature/checking assembly and genebuild changes

### DIFF
--- a/modules/Bio/EnsEMBL/MetaData/MetadataUpdater.pm
+++ b/modules/Bio/EnsEMBL/MetaData/MetadataUpdater.pm
@@ -465,8 +465,14 @@ sub process_core {
   my ($species,$metadatadba,$gdba,$db_type,$database,$species_ids,$email,$update_type,$comment,$source) = @_;
   my @events;
   foreach my $species_name (@{$species}){
+    my $update=$update_type;
     my $dba=create_database_dba($database,$species_name,$db_type,$species_ids);
     $log->info("Processing $species_name in database ".$dba->dbc()->dbname());
+    #Check if this is a new genebuild
+    $update = check_new_genebuild($dba, $gdba, $species_name, $update);
+    #Check if this is a new assembly
+    my $old_assembly_database_list;
+    ($update,$old_assembly_database_list) = check_new_assembly($dba, $gdba, $species_name, $update);
     my $opts = { -INFO_ADAPTOR => $gdba,
                 -ANNOTATION_ANALYZER =>
                   Bio::EnsEMBL::MetaData::AnnotationAnalyzer->new(),
@@ -481,10 +487,12 @@ sub process_core {
     $gdba->store($md);
     my $ea = $metadatadba->get_EventInfoAdaptor();
     $log->info( "Storing event for $species_name in database ".$dba->dbc()->dbname() );
+    my $event_details={"email"=>$email,"comment"=>$comment};
+    $event_details->{'old_assembly_database_list'} = $old_assembly_database_list if defined $old_assembly_database_list;
     my $event = Bio::EnsEMBL::MetaData::EventInfo->new( -SUBJECT => $md,
-                                                    -TYPE    => $update_type,
+                                                    -TYPE    => $update,
                                                     -SOURCE  => $source,
-                                                    -DETAILS => encode_json({"email"=>$email,"comment"=>$comment}) ); 
+                                                    -DETAILS => encode_json($event_details) );
     $ea->store( $event );
     my $event_hash = to_hash($event);
     push @events, $event_hash;
@@ -578,4 +586,61 @@ sub to_hash {
   $event_hash{'genome'}=$event->{subject}->{organism}->{name};
   return \%event_hash;
 }
+
+sub check_new_assembly {
+  #Check the core database assembly value and compare it with what we have in the Metadata database
+  #if the assembly doesn't exist in the metadata database then it's a new species, update the handover type
+  #if the assembly is the same, all good, nothing to do here
+  #if the assembly is different, make sure that we update the handover type and generate a list of old assembly databases to clean up except for collections
+  my ($dba, $gdba, $species_name, $update_type) = @_;
+  my $old_assembly_database_list;
+  my $meta = $dba->get_MetaContainer();
+  my $assembly_default = $meta->single_value_by_key('assembly.default');
+  my $md = $gdba->fetch_by_name($species_name);
+  #Checking if this is a new species
+  if (defined $md){
+    if ($assembly_default ne $md->assembly()->{assembly_default}){
+      $update_type = 'new_assembly';
+      # We don't want to drop the database if a genome in a collection has changed.
+      if ($dba->dbc->dbname !~ /_collection_/){
+        my $old_databases = $md->databases();
+        foreach my $old_database (@{$old_databases})
+        {
+          push @{$old_assembly_database_list}, $old_database->dbname
+        }
+      }
+    }
+  }
+  #If the species is not in the metadata database then flag is as a new assembly
+  else {
+    $update_type = 'new_assembly';
+  }
+  return ($update_type,$old_assembly_database_list);
+}
+
+sub check_new_genebuild {
+  # Check the core database genebuild.version or (genebuild.start_date/genebuild.last_geneset_update) value and compare it with what we have in the Metadata database
+  #if the Genebuild is the same, all good, nothing to do here
+  #if the Genebuild is different, make sure that we update the handover type
+  my ($dba, $gdba, $species_name, $update_type) = @_;
+  my $old_assembly_database_list;
+  my $meta = $dba->get_MetaContainer();
+  my ($genebuild)        = @{$meta->list_value_by_key('genebuild.start_date')};
+  my ($genebuild_version)= @{$meta->list_value_by_key('genebuild.version')};
+  my ($genebuild_upd)    = @{$meta->list_value_by_key('genebuild.last_geneset_update')};
+  my $gb_string = $genebuild_version;
+  if(!defined $gb_string) {
+    $gb_string = $genebuild;
+    $gb_string .= "/".$genebuild_upd if defined $genebuild_upd;
+  }
+  my $md = $gdba->fetch_by_name($species_name);
+  #If this species exist already
+  if (defined $md){
+    if ($gb_string ne $md->genebuild()){
+      $update_type = 'new_genebuild';
+    }
+  }
+  return ($update_type);
+}
+
 1;


### PR DESCRIPTION
Added new checks using the core meta table and metadata database to find out if a handed over database is on a new assembly or new genebuild. If the assembly is the same then the metadata updater will carry on with the database and keep the original update_type flag. If the species is not found in the metadata database then we will consider it as a new species, the update_type flag will be set to new_assembly. If the assembly is different between the core database and the metadata database, set the update_flag to new assembly and gather the list of old assembly databases. The list of database will be added to the event details. Similar behaviour for new genebuild.