### PR TITLE
Added new check to make sure that the species array is not empty. Thi…

### DIFF
--- a/modules/Bio/EnsEMBL/MetaData/MetadataUpdater.pm
+++ b/modules/Bio/EnsEMBL/MetaData/MetadataUpdater.pm
@@ -592,7 +592,7 @@ sub to_hash {
 
 sub check_array_ref_empty {
   my ($array_ref) = @_;
-  return (scalar @$array_ref);
+  return scalar @$array_ref;
 }
 
 sub check_new_assembly {

--- a/modules/Bio/EnsEMBL/MetaData/MetadataUpdater.pm
+++ b/modules/Bio/EnsEMBL/MetaData/MetadataUpdater.pm
@@ -376,6 +376,7 @@ sub get_db_connection_params {
 #Subroutine to process compara database and add or force update
 sub process_compara {
   my ($species,$metadatadba,$gdba,$db_type,$database,$species_ids,$email,$update_type,$comment,$source) = @_;
+  die "Problem with ".$database->{dbname}.", can't find compara name" if !check_array_ref_empty($species);
   my $dba=create_database_dba($database,$species,$db_type,$species_ids);
   my @events;
   my $cdba = $metadatadba->get_GenomeComparaInfoAdaptor();
@@ -463,6 +464,7 @@ sub process_release_database {
 #Subroutine to add or force update a species database
 sub process_core {
   my ($species,$metadatadba,$gdba,$db_type,$database,$species_ids,$email,$update_type,$comment,$source) = @_;
+  die "Problem with ".$database->{dbname}.", can't find species name. Check species.production_name meta key" if !check_array_ref_empty($species);
   my @events;
   foreach my $species_name (@{$species}){
     my $update=$update_type;
@@ -504,6 +506,7 @@ sub process_core {
 #Subroutine to add or force update a species database
 sub process_other_database {
   my ($species,$metadatadba,$gdba,$db_type,$database,$species_ids,$email,$update_type,$comment,$source) = @_;
+  die "Problem with ".$database->{dbname}.", can't find species name. Check species.production_name meta key" if !check_array_ref_empty($species);
   my @events;
   foreach my $species_name (@{$species}){
     my $dba=create_database_dba($database,$species_name,$db_type,$species_ids);
@@ -585,6 +588,16 @@ sub to_hash {
   $event_hash{'type'} = $event->{type};
   $event_hash{'genome'}=$event->{subject}->{organism}->{name};
   return \%event_hash;
+}
+
+sub check_array_ref_empty {
+  my ($array_ref) = @_;
+  if (scalar @$array_ref == 0){
+    return 0;
+  }
+  else {
+    return 1;
+  }
 }
 
 sub check_new_assembly {

--- a/modules/Bio/EnsEMBL/MetaData/MetadataUpdater.pm
+++ b/modules/Bio/EnsEMBL/MetaData/MetadataUpdater.pm
@@ -592,12 +592,7 @@ sub to_hash {
 
 sub check_array_ref_empty {
   my ($array_ref) = @_;
-  if (scalar @$array_ref == 0){
-    return 0;
-  }
-  else {
-    return 1;
-  }
+  return (scalar @$array_ref);
 }
 
 sub check_new_assembly {


### PR DESCRIPTION
…s can be empty is we are missing the species.production_name meta key in core and core like or something wrong with Compara db.
This is related to this Jira ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSPROD-2688
