### PR TITLE
In release EG42, Drosophila assembly_default changed but not the asse…

### DIFF
--- a/modules/Bio/EnsEMBL/MetaData/DBSQL/GenomeAssemblyInfoAdaptor.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DBSQL/GenomeAssemblyInfoAdaptor.pm
@@ -76,16 +76,26 @@ sub store {
   if ( !defined $assembly->dbID() ) {
     # find out if assembly exists first
     my $dbID;
-    if(defined $assembly->assembly_accession()) {
-      # try to use the unique assembly accession
+    if(defined $assembly->assembly_accession() and defined $assembly->assembly_default()) {
+      # try to use the unique pair assembly accession and assembly default
             ($dbID) =
       @{
       $self->dbc()->sql_helper()->execute_simple(
         -SQL =>
-"select assembly_id from assembly where assembly_accession=?",
-        -PARAMS => [ $assembly->assembly_accession() ]
+"select assembly_id from assembly where assembly_accession=? and assembly_default=?",
+        -PARAMS => [ $assembly->assembly_accession(), $assembly->assembly_default() ]
       ) };   
-    } else {
+    } elsif (defined $assembly->assembly_default()) {
+      # Try with the assembly default if it exists
+      ($dbID) =
+      @{
+      $self->dbc()->sql_helper()->execute_simple(
+        -SQL =>
+"select assembly_id from assembly where assembly_default=?",
+        -PARAMS => [ $assembly->assembly_default() ]
+      ) };
+    }
+    else {
       # otherwise, we have to assume the name is unique :-(
       ($dbID) =
       @{

--- a/modules/t/test-genome-DBs/multi/empty_metadata/table.sql
+++ b/modules/t/test-genome-DBs/multi/empty_metadata/table.sql
@@ -31,7 +31,7 @@ CREATE TABLE `assembly` (
   `assembly_level` varchar(50) NOT NULL,
   `base_count` bigint(20) unsigned NOT NULL,
   PRIMARY KEY (`assembly_id`),
-  UNIQUE KEY `assembly_accession_idx` (`assembly_accession`)
+  UNIQUE KEY `assembly_accession_idx` (`assembly_accession`,`assembly_default`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/sql/patch_26112018_m.sql
+++ b/sql/patch_26112018_m.sql
@@ -18,4 +18,4 @@
 #
 # Description: Update Assemnly unique index to allow more flexibility, I think its fine if a genome as duplicated accession as long as the assembly name and default are different
 DROP INDEX assembly_accession_idx on assembly;
-ALTER TABLE assembly ADD UNIQUE assembly_idx (assembly_accession,assembly_default,assembly_name);
+ALTER TABLE assembly ADD UNIQUE assembly_idx (assembly_accession,assembly_default);

--- a/sql/patch_26112018_m.sql
+++ b/sql/patch_26112018_m.sql
@@ -1,0 +1,21 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2018] EMBL-European Bioinformatics Institute
+-- 
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+-- 
+--      http://www.apache.org/licenses/LICENSE-2.0
+-- 
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+# patch_26112018_m
+#
+# Title: Update Assembly unique index to allow more flexibility
+#
+# Description: Update Assemnly unique index to allow more flexibility, I think its fine if a genome as duplicated accession as long as the assembly name and default are different
+DROP INDEX assembly_accession_idx on assembly;
+ALTER TABLE assembly ADD UNIQUE assembly_idx (assembly_accession,assembly_default,assembly_name);


### PR DESCRIPTION
…mbly_accession so as a result metadata code didn't consider this as a new assembly. As a result, metadata code updated assembly_default and assembly_name for all the previous releases which is wrong. I've updated the code to check both assembly_accession and assembly_default and also changed the unique index on assembly_accession in the assembly table to a join index on assembly_accession,assembly_default.