### PR TITLE
When the same worker process two databases for the same organism, it …

### DIFF
--- a/modules/Bio/EnsEMBL/MetaData/MetadataUpdater.pm
+++ b/modules/Bio/EnsEMBL/MetaData/MetadataUpdater.pm
@@ -66,6 +66,7 @@ sub process_database {
     $events = process_other_database($species,$metadatadba,$gdba,$db_type,$database,$species_ids,$email,$comment,$source,$dba);
   }
   # Disconnecting from server
+  $gdba->_clear_cache();
   $gdba->dbc()->disconnect_if_idle();
   $metadatadba->dbc()->disconnect_if_idle();
   $log->info("All done");
@@ -177,7 +178,6 @@ sub get_release_and_process_release_db {
 }
 sub get_species_and_dbtype {
   my ($database_uri)=@_;
-  $DB::single = 1;
   my $database = get_db_connection_params($database_uri);
   my ($db_type,$species,$dba,$species_ids);
   $log->info("Connecting to database $database->{dbname}");


### PR DESCRIPTION
…caches information after processing the first database. This cached information is reused when processing the second database. This cause issues and the second job silently fails meaning that we are now missing the database from the metadata database. Clearing the cache at the end of the module fix this issue