### PR TITLE
If no division option is given to the script then it will query to fi…

### DIFF
--- a/misc_scripts/report_genomes.pl
+++ b/misc_scripts/report_genomes.pl
@@ -101,7 +101,7 @@ use warnings;
 use Pod::Usage;
 use Bio::EnsEMBL::Utils::CliHelper;
 use Bio::EnsEMBL::DBSQL::DBConnection;
-use  Bio::EnsEMBL::MetaData::DBSQL::MetaDataDBAdaptor;
+use Bio::EnsEMBL::MetaData::DBSQL::MetaDataDBAdaptor;
 use Log::Log4perl qw(:easy);
 use Data::Dumper;
 use Carp;
@@ -124,66 +124,74 @@ my $gdba = $metadatadba->get_GenomeInfoAdaptor();
 my $rdba = $metadatadba->get_DataReleaseInfoAdaptor();
 my $release_info;
 my $release;
-my $division_name;
-my $division;
 
-#Creating the Division name EnsemblBla and division bla variables
-if ($opts->{division} !~ m/[E|e]nsembl/){
-  $division = $opts->{division};
-  $division_name = 'Ensembl'.ucfirst($opts->{division}) if defined $opts->{division};
+# get all divisions
+my $dump_all = 0;
+if ( !defined $opts->{division} ) {
+  $opts->{divisions} = $gdba->list_divisions();
+  $dump_all = 1;
 }
-else{
-  $division_name = $opts->{division};
-  $division = $opts->{division};
-  $division =~ s/Ensembl//;
-  $division = lc($division);
+else {
+  $opts->{divisions} = [ $opts->{'division'} ];
 }
 
-#Get the release for the given division
-if (defined $opts->{release}){
-  $release_info = $rdba->fetch_by_ensembl_genomes_release($opts->{release});
-  if (!$release_info){
-    $release_info = $rdba->fetch_by_ensembl_release($opts->{release});
-    $release = $release_info->{ensembl_version};
+foreach my $division (@{$opts->{divisions}}){
+  my $division_name;
+  #Creating the Division name EnsemblBla and division bla variables
+  if ($division !~ m/[E|e]nsembl/){
+    $division_name = 'Ensembl'.ucfirst($opts->{division}) if defined $opts->{division};
   }
   else{
-    $release = $release_info->{ensembl_genomes_version};
+    $division_name = $division;
+    $division =~ s/Ensembl//;
+    $division = lc($division);
   }
-  $gdba->data_release($release_info);
-}
-else{
-  $release_info = $rdba->fetch_current_ensembl_release();
-  if (!$release_info){
-    $release_info = $rdba->fetch_current_ensembl_genomes_release();
-    $release = $release_info->{ensembl_genomes_version};
+
+  #Get the release for the given division
+  if (defined $opts->{release}){
+    $release_info = $rdba->fetch_by_ensembl_genomes_release($opts->{release});
+    if (!$release_info){
+      $release_info = $rdba->fetch_by_ensembl_release($opts->{release});
+      $release = $release_info->{ensembl_version};
+    }
+    else{
+      $release = $release_info->{ensembl_genomes_version};
+    }
+    $gdba->data_release($release_info);
   }
   else{
-    $release = $release_info->{ensembl_version};
+    $release_info = $rdba->fetch_current_ensembl_release();
+    if (!$release_info){
+      $release_info = $rdba->fetch_current_ensembl_genomes_release();
+      $release = $release_info->{ensembl_genomes_version};
+    }
+    else{
+      $release = $release_info->{ensembl_version};
+    }
+    $gdba->data_release($release_info);
   }
-  $gdba->data_release($release_info);
-}
 
-my $report = {
-	      eg_version=> $gdba->data_release()->ensembl_genomes_version(),
-	      ensembl_version=> $gdba->data_release()->ensembl_version()
-};
+  my $report = {
+   eg_version=> $gdba->data_release()->ensembl_genomes_version(),
+   ensembl_version=> $gdba->data_release()->ensembl_version()
+ };
 
-$logger->info("Getting genomes from release ".$release." for ".$division);
-my $genomes = get_genomes($gdba, $division_name);
-$logger->info("Found ".scalar(keys %$genomes)." genomes from from release ".$release." for ".$division);
+ $logger->info("Getting genomes from release ".$release." for ".$division);
+ my $genomes = get_genomes($gdba, $division_name);
+ $logger->info("Found ".scalar(keys %$genomes)." genomes from from release ".$release." for ".$division);
 # decrement releases
 if ( $division eq "vertebrates" ) {
   my $prev_ens = $gdba->data_release()->ensembl_version()-1;
   $logger->info("Switching release to Ensembl $prev_ens");
   $gdba->set_ensembl_release($prev_ens);
-} else {
-  my $prev_eg = $gdba->data_release()->ensembl_genomes_version()-1;
-  $logger->info("Switching release to EG $prev_eg");
-  $gdba->set_ensembl_genomes_release($gdba->data_release()->ensembl_genomes_version()-1);
-}
-$logger->info("Getting genomes from previous release for ".$division);
-my $prev_genomes = get_genomes($gdba, $division_name);
-$logger->info("Found ".scalar(keys %$prev_genomes)." genomes from previous release for ".$division);
+  } else {
+    my $prev_eg = $gdba->data_release()->ensembl_genomes_version()-1;
+    $logger->info("Switching release to EG $prev_eg");
+    $gdba->set_ensembl_genomes_release($gdba->data_release()->ensembl_genomes_version()-1);
+  }
+  $logger->info("Getting genomes from previous release for ".$division);
+  my $prev_genomes = get_genomes($gdba, $division_name);
+  $logger->info("Found ".scalar(keys %$prev_genomes)." genomes from previous release for ".$division);
 
 # new genomes
 my $new_genomes = [];
@@ -201,7 +209,7 @@ my $dbs = {};
 my $species = {};
 $logger->info("Comparing releases");
 my @set_chains = sort keys %{$genomes};
-foreach my $set_chain (@set_chains) {
+foreach my $set_chain (sort @set_chains) {
   my $genome = $genomes->{$set_chain};
   $species->{$genome->{species_taxonomy_id}}++;
   $dbs->{$genome->{database}}++;
@@ -210,127 +218,126 @@ foreach my $set_chain (@set_chains) {
   my $prev_genome = $prev_genomes->{$set_chain};
   if (!defined $prev_genome) {
     push @$new_genomes, $genome;
-  } else {
-    if ($genome->{name} ne $prev_genome->{name}) {
-      push @$renamed_genomes, {new => $genome, old => $prev_genome};
+    } else {
+      if ($genome->{name} ne $prev_genome->{name}) {
+        push @$renamed_genomes, {new => $genome, old => $prev_genome};
+      }
+      if ($genome->{assembly} ne $prev_genome->{assembly}) {
+        push @$new_assemblies, {new => $genome, old => $prev_genome};
+        } elsif ($genome->{genebuild} ne $prev_genome->{genebuild}) {
+          push @$new_annotations, {new => $genome, old => $prev_genome};
+        }
+      }
     }
-    if ($genome->{assembly} ne $prev_genome->{assembly}) {
-      push @$new_assemblies, {new => $genome, old => $prev_genome};
-    } elsif ($genome->{genebuild} ne $prev_genome->{genebuild}) {
-      push @$new_annotations, {new => $genome, old => $prev_genome};
-    }
-  }
-}
- 
-while (my ($set_chain, $genome) = each %{$prev_genomes->{genomes}}) {
-    if (!defined $genomes->{genomes}->{$set_chain}) {
-	push @$removed_genomes, $genome;
-    }
-  } 
-$report->{databases} = scalar keys %$dbs;
-$report->{species} = scalar keys %$species;
-$report->{new_genomes}     = scalar @$new_genomes;
-$report->{new_assemblies}  = scalar @$new_assemblies;
-$report->{new_annotations} = scalar @$new_annotations;
-$report->{renamed_genomes} = scalar @$renamed_genomes;
-$report->{removed_genomes} = scalar @$removed_genomes;
+
+    while (my ($set_chain, $genome) = each %{$prev_genomes->{genomes}}) {
+      if (!defined $genomes->{genomes}->{$set_chain}) {
+       push @$removed_genomes, $genome;
+     }
+   } 
+   $report->{databases} = scalar keys %$dbs;
+   $report->{species} = scalar keys %$species;
+   $report->{new_genomes}     = scalar @$new_genomes;
+   $report->{new_assemblies}  = scalar @$new_assemblies;
+   $report->{new_annotations} = scalar @$new_annotations;
+   $report->{renamed_genomes} = scalar @$renamed_genomes;
+   $report->{removed_genomes} = scalar @$removed_genomes;
 
 
 # print to file
 # new genomes
 # name assembly database species_id
-write_to_file(
+  write_to_file(
     $new_genomes,
-    "new_genomes.txt",
+    $dump_all ? "$division-new_genomes.txt" : "new_genomes.txt",
     [qw/name assembly database species_id/],
     sub {
-	return [$_[0]->{name}, $_[0]->{assembly}, $_[0]->{database}, $_[0]->{species_id}];
-    });
+     return [$_[0]->{name}, $_[0]->{assembly}, $_[0]->{database}, $_[0]->{species_id}];
+     });
 
 # updated assemblies
 # name old_assembly new_assembly database species_id
-write_to_file(
+  write_to_file(
     $new_assemblies,
-    "updated_assemblies.txt",
+    $dump_all ? "$division-updates_assemblies.txt" : "updated_assemblies.txt",
     [qw/name assembly old_assembly  database species_id/],
     sub {
-	return [$_[0]->{new}->{name}, $_[0]->{new}->{assembly}, $_[0]->{old}->{assembly}, $_[0]->{new}->{database}, $_[0]->{new}->{species_id}];
-    });
+     return [$_[0]->{new}->{name}, $_[0]->{new}->{assembly}, $_[0]->{old}->{assembly}, $_[0]->{new}->{database}, $_[0]->{new}->{species_id}];
+     });
 
 # updated annotation
 # name assembly old_genebuild new_genebuild database species_id
-write_to_file(
+  write_to_file(
     $new_annotations,
-    "updated_annotations.txt",
+    $dump_all ? "$division-updated_annotations.txt" : "updated_annotations.txt",
     [qw/name assembly new_genebuild old_genebuild database species_id/],
     sub {
-        return [$_[0]->{new}->{name}, $_[0]->{new}->{assembly}, $_[0]->{new}->{genebuild}, $_[0]->{old}->{genebuild}, $_[0]->{new}->{database}, $_[0]->{new}->{species_id}];
-    });
+      return [$_[0]->{new}->{name}, $_[0]->{new}->{assembly}, $_[0]->{new}->{genebuild}, $_[0]->{old}->{genebuild}, $_[0]->{new}->{database}, $_[0]->{new}->{species_id}];
+      });
 
 # renamed genomes
 # name assembly old_name database species_id
-write_to_file(
+  write_to_file(
     $renamed_genomes,
-    "renamed_genomes.txt",
+    $dump_all ? "$division-renamed_genomes.txt" : "renamed_genomes.txt",
     [qw/ name assembly old_name database species_id /],
     sub {
-	return [$_[0]->{new}->{name}, $_[0]->{new}->{assembly}, $_[0]->{old}->{name}, $_[0]->{new}->{database}, $_[0]->{new}->{species_id}];
-    });
+     return [$_[0]->{new}->{name}, $_[0]->{new}->{assembly}, $_[0]->{old}->{name}, $_[0]->{new}->{database}, $_[0]->{new}->{species_id}];
+     });
 
 # removed genomes
 # name assembly database species_id
-write_to_file(
+  write_to_file(
     $removed_genomes,
-    "removed_genomes.txt",
+    $dump_all ? "$division-renamed_genomes.txt" : "removed_genomes.txt",
     [qw/ name assembly database species_id /],
     sub {
-        return [$_[0]->{name}, $_[0]->{assembly}, $_[0]->{database}, $_[0]->{species_id}];
-    });
+      return [$_[0]->{name}, $_[0]->{assembly}, $_[0]->{database}, $_[0]->{species_id}];
+      });
 
 
-my $summary_file = "summary.txt";
-$logger->info("Writing summary to $summary_file");
-my $news='';
-my $url;
-if ($division eq "vertebrates"){
-  $url = "ftp://ftp.ensembl.org/pub/release-".$release."/"
-}
-else{
-  $url = "ftp://ftp.ensemblgenomes.org/pub/release-".$release."/$division/";
-}
+  my $summary_file = $dump_all ? "$division-summary.txt" : "summary.txt";
+  $logger->info("Writing summary to $summary_file");
+  my $news='';
+  my $url;
+  if ($division eq "vertebrates"){
+    $url = "ftp://ftp.ensembl.org/pub/release-".$release."/"
+  }
+  else{
+    $url = "ftp://ftp.ensemblgenomes.org/pub/release-".$release."/$division/";
+  }
 
-if($division eq 'bacteria') {
-  # get counts of bacteria and archaea
-  my $taxon_sql = q/select count(*) from ncbi_taxonomy.ncbi_taxa_name n join ncbi_taxonomy.ncbi_taxa_node p on (n.taxon_id=p.taxon_id) join ncbi_taxonomy.ncbi_taxa_node c on (c.left_index between p.left_index and p.right_index) join organism o on (o.taxonomy_id=c.taxon_id) join genome using (organism_id) where n.name=? and n.name_class='scientific name' and data_release_id=?/;
-  $report->{bacteria} = $gdba->dbc()->sql_helper()->execute_single_result(-SQL=>$taxon_sql, -PARAMS=>['Bacteria',$gdba->data_release()->dbID()]);
-  $report->{archaea} = $gdba->dbc()->sql_helper()->execute_single_result(-SQL=>$taxon_sql, -PARAMS=>['Archaea',$gdba->data_release()->dbID()]);
-  $news = <<"END_B";
+  if($division eq 'bacteria') {
+    # get counts of bacteria and archaea
+    my $taxon_sql = q/select count(*) from ncbi_taxonomy.ncbi_taxa_name n join ncbi_taxonomy.ncbi_taxa_node p on (n.taxon_id=p.taxon_id) join ncbi_taxonomy.ncbi_taxa_node c on (c.left_index between p.left_index and p.right_index) join organism o on (o.taxonomy_id=c.taxon_id) join genome using (organism_id) where n.name=? and n.name_class='scientific name' and data_release_id=?/;
+    $report->{bacteria} = $gdba->dbc()->sql_helper()->execute_single_result(-SQL=>$taxon_sql, -PARAMS=>['Bacteria',$gdba->data_release()->dbID()]);
+    $report->{archaea} = $gdba->dbc()->sql_helper()->execute_single_result(-SQL=>$taxon_sql, -PARAMS=>['Archaea',$gdba->data_release()->dbID()]);
+    $news = <<"END_B";
 Release $release of Ensembl $division has been loaded from EMBL-Bank release XXX into $report->{databases} multispecies Ensembl v$report->{ensembl_version} databases.  The current dataset contains $report->{genomes} genomes ($report->{bacteria} bacteria and $report->{archaea} archaea) from $report->{species} species containing $report->{protein_coding} protein coding genes. This release includes <a href="${url}new_genomes.txt">$report->{new_genomes}</a> new genomes, <a href="${url}updated_assemblies.txt">$report->{new_assemblies} genomes with updated assemblies, <a href="${url}updated_annotations.txt">$report->{new_annotations}</a> genomes with updated annotation, <a href="${url}renamed_genomes.txt">$report->{renamed_genomes}</a> genomes where the assigned name has changed, and <a href="${url}removed_genomes.txt">$report->{removed_genomes}</a> genomes removed since the last release.
 
 Ensembl Bacteria has been updated to include the latest versions of $report->{genomes} genomes ($report->{eubacteria} bacteria and $report->{archaea} archaea) from the INSDC archives.
 END_B
 
-} else {
-
+  } else {
     $news = <<"END";
 Release $release of Ensembl $division has been loaded into $report->{databases} Ensembl v$report->{ensembl_version} databases.  The current dataset contains $report->{genomes} genomes from $report->{species} species containing $report->{protein_coding} protein coding genes. This release includes <a href="${url}new_genomes.txt">$report->{new_genomes}</a> new genomes, <a href="${url}updated_assemblies.txt">$report->{new_assemblies}</a> genomes with updated assemblies, <a href="${url}updated_annotations.txt">$report->{new_annotations}</a> genomes with updated annotation, <a href="${url}renamed_genomes.txt">$report->{renamed_genomes}</a> genomes where the assigned name has changed, and <a href="${url}removed_genomes.txt">$report->{removed_genomes}</a> genomes removed since the last release.
 END
 
+  }
+  open my $summary, ">", "$summary_file" || croak "Could not open $summary_file for writing";
+  print $summary $news;
+  close $summary;
 }
 
-open my $summary, ">", "$summary_file" || croak "Could not open $summary_file for writing";
-print $summary $news;
-close $summary;
-
 sub write_to_file {
-    my ($data, $file_name, $header, $callback) = @_;
-    $logger->info("Writing to $file_name");
-    open my $file, ">", $file_name or croak "Could not open output file $file_name";
-    print $file "#".join("\t", @{$header}) . "\n";
-    for my $datum (@{$data}) {
-	print $file join("\t", @{$callback->($datum)}) . "\n";
-    }
-    close $file;
+  my ($data, $file_name, $header, $callback) = @_;
+  $logger->info("Writing to $file_name");
+  open my $file, ">", $file_name or croak "Could not open output file $file_name";
+  print $file "#".join("\t", @{$header}) . "\n";
+  for my $datum (@{$data}) {
+   print $file join("\t", @{$callback->($datum)}) . "\n";
+ }
+ close $file;
 }
 
 sub get_genomes {
@@ -339,28 +346,28 @@ sub get_genomes {
   my $genomes = {};
   if(defined $division) { 
     $genomes = $gdba->fetch_all_by_division($division);
-  } else {
-    $genomes = $gdba->fetch_all();
-  }
-  my $dbs = {};
-  for my $genome (@{$genomes}) {
-    # name
-    my $gd = {
-	      name=>$genome->name(),
-	      assembly=>$genome->assembly_default(),
-	      genebuild=>$genome->genebuild(),
-	      database=>$genome->dbname(),
-	      species_id=>$genome->species_id(),
-	      species_taxonomy_id=>($genome->organism()->species_taxonomy_id() || $genome->organism()->taxonomy_id()),
-	      protein_coding=>$genome->annotations()->{nProteinCoding}
-	     };
-    my $key;
-    if($genome->dbname() =~ m/collection_core/) {
-      ($key) = split(/\./, $genome->assembly_accession());
     } else {
-      $key = $gd->{name};
+      $genomes = $gdba->fetch_all();
     }
-    $genome_details->{$key} = $gd;    
+    my $dbs = {};
+    for my $genome (@{$genomes}) {
+      # name
+      my $gd = {
+       name=>$genome->name(),
+       assembly=>$genome->assembly_default(),
+       genebuild=>$genome->genebuild(),
+       database=>$genome->dbname(),
+       species_id=>$genome->species_id(),
+       species_taxonomy_id=>($genome->organism()->species_taxonomy_id() || $genome->organism()->taxonomy_id()),
+       protein_coding=>$genome->annotations()->{nProteinCoding}
+     };
+     my $key;
+     if($genome->dbname() =~ m/collection_core/) {
+      ($key) = split(/\./, $genome->assembly_accession());
+      } else {
+        $key = $gd->{name};
+      }
+      $genome_details->{$key} = $gd;    
+    }
+    return $genome_details;
   }
-  return $genome_details;
-}


### PR DESCRIPTION
…nd all and then run against each. If division is specified then the output is the same as before this commit

I don't expect you to accept this but it demonstrates how we'd like to use this, ie to be able to run it once over all divisions when you hand over to us.

The other thing that we'd like to be able to do is to have the output to SDTOUT rather than files, but that's more involved when it comes to running against all divisions