### PR TITLE
Adding support for retired vega database type

### DIFF
--- a/modules/t/test-genome-DBs/multi/empty_metadata/table.sql
+++ b/modules/t/test-genome-DBs/multi/empty_metadata/table.sql
@@ -275,7 +275,7 @@ CREATE TABLE `genome_database` (
   `genome_id` int(10) unsigned NOT NULL,
   `dbname` varchar(64) NOT NULL,
   `species_id` int(10) unsigned NOT NULL,
-  `type` enum('core','funcgen','variation','otherfeatures','rnaseq','cdna') DEFAULT NULL,
+  `type` enum('core','funcgen','variation','otherfeatures','rnaseq','cdna','vega') DEFAULT NULL,
   PRIMARY KEY (`genome_database_id`),
   UNIQUE KEY `id_dbname` (`genome_id`,`dbname`),
   UNIQUE KEY `dbname_species_id` (`dbname`,`species_id`),

--- a/sql/patch_01022019_o.sql
+++ b/sql/patch_01022019_o.sql
@@ -1,0 +1,20 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2019] EMBL-European Bioinformatics Institute
+-- 
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+-- 
+--      http://www.apache.org/licenses/LICENSE-2.0
+-- 
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+# patch_01022019_o
+#
+# Title: Add support for Ensembl Vega database type
+#
+# Description: Add support for old Ensembl Vega database type
+ALTER TABLE genome_database MODIFY COLUMN type enum('core','funcgen','variation','otherfeatures','rnaseq','cdna','vega') DEFAULT NULL;

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -275,7 +275,7 @@ CREATE TABLE `genome_database` (
   `genome_id` int(10) unsigned NOT NULL,
   `dbname` varchar(64) NOT NULL,
   `species_id` int(10) unsigned NOT NULL,
-  `type` enum('core','funcgen','variation','otherfeatures','rnaseq','cdna') DEFAULT NULL,
+  `type` enum('core','funcgen','variation','otherfeatures','rnaseq','cdna','vega') DEFAULT NULL,
   PRIMARY KEY (`genome_database_id`),
   UNIQUE KEY `id_dbname` (`genome_id`,`dbname`),
   UNIQUE KEY `dbname_species_id` (`dbname`,`species_id`),


### PR DESCRIPTION
While populating the missing databases in older releases because of this bug: https://github.com/Ensembl/ensembl-metadata/pull/36
I noticed that we are missing the now retired ensembl data type "vega". These databases should be there for historical consistency.