### PR TITLE
Improve check assembly genebuild updates

### DIFF
--- a/modules/Bio/EnsEMBL/MetaData/Base.pm
+++ b/modules/Bio/EnsEMBL/MetaData/Base.pm
@@ -43,7 +43,7 @@ use warnings;
 package Bio::EnsEMBL::MetaData::Base;
 use Bio::EnsEMBL::Utils::Argument qw(rearrange);
 use Exporter qw/import/;
-our @EXPORT_OK = qw(get_division process_division_names fetch_and_set_release);
+our @EXPORT_OK = qw(get_division process_division_names fetch_and_set_release check_assembly_update check_genebuild_update);
 
 =head2 get_division
   Description: Get division for a given database adaptor. If the database is a core like, get the core database
@@ -159,6 +159,43 @@ sub fetch_and_set_release {
     $gdba->data_release($release_info);
   }
   return ($rdba,$gdba,$release,$release_info);
+}
+
+=head2 check_assembly_update
+  Description: Compare assembly information between two genomes from different releases and check if the assembly has been updated.
+  Arg        : Current release genome object
+  Arg        : Previous release genome object
+  Returntype : string
+  Exceptions : none
+  Caller     : Internal
+  Status     : Stable
+=cut
+sub check_assembly_update {
+  my ($genome,$prev_genome) = @_;
+  my $updated_assembly=0;
+  # Check assembly default meta key
+  $updated_assembly = 1 if $genome->assembly_default() ne $prev_genome->assembly_default();
+  # Check base_count value which is the sum of lenght of seq_region. If new sequences have been added to the assembly, this will change.
+  # We can pick up new MT or scaffolds
+  $updated_assembly = 1 if $genome->base_count() ne $prev_genome->base_count();
+  return $updated_assembly;
+}
+
+
+=head2 check_genebuild_update
+  Description: Compare genebuild information between two genomes from different releases and check if the gene set has been updated.
+  Arg        : Current release genome object
+  Arg        : Previous release genome object
+  Returntype : string
+  Exceptions : none
+  Caller     : Internal
+  Status     : Stable
+=cut
+sub check_genebuild_update {
+  my ($genome,$prev_genome) = @_;
+  my $updated_genebuild = 0;
+  $updated_genebuild = 1 if $genome->genebuild() ne $prev_genome->genebuild();
+  return $updated_genebuild;
 }
 
 1;

--- a/modules/Bio/EnsEMBL/MetaData/DBSQL/GenomeAssemblyInfoAdaptor.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DBSQL/GenomeAssemblyInfoAdaptor.pm
@@ -77,22 +77,22 @@ sub store {
     # find out if assembly exists first
     my $dbID;
     if(defined $assembly->assembly_accession() and defined $assembly->assembly_default()) {
-      # try to use the unique pair assembly accession and assembly default
+      # try to use the unique pair assembly accession, assembly default and base_count
             ($dbID) =
       @{
       $self->dbc()->sql_helper()->execute_simple(
         -SQL =>
-"select assembly_id from assembly where assembly_accession=? and assembly_default=?",
-        -PARAMS => [ $assembly->assembly_accession(), $assembly->assembly_default() ]
+"select assembly_id from assembly where assembly_accession=? and assembly_default=? and base_count=?",
+        -PARAMS => [ $assembly->assembly_accession(), $assembly->assembly_default(), $assembly->base_count() ]
       ) };   
     } elsif (defined $assembly->assembly_default()) {
-      # Try with the assembly default if it exists
+      # Try with the assembly default and base_count if they exists
       ($dbID) =
       @{
       $self->dbc()->sql_helper()->execute_simple(
         -SQL =>
-"select assembly_id from assembly where assembly_default=?",
-        -PARAMS => [ $assembly->assembly_default() ]
+"select assembly_id from assembly where assembly_default=? and base_count=?",
+        -PARAMS => [ $assembly->assembly_default(),$assembly->base_count() ]
       ) };
     }
     else {
@@ -101,8 +101,8 @@ sub store {
       @{
       $self->dbc()->sql_helper()->execute_simple(
         -SQL =>
-"select assembly_id from assembly where assembly_name=?",
-        -PARAMS => [ $assembly->assembly_name() ]
+"select assembly_id from assembly where assembly_name=? and base_count=?",
+        -PARAMS => [ $assembly->assembly_name(), $assembly->base_count() ]
       ) };
     }
     if ( defined $dbID ) {
@@ -157,7 +157,6 @@ q/update assembly set assembly_accession=?,assembly_name=?,assembly_default=?,as
                  $assembly->assembly_default(),   $assembly->assembly_ucsc(),
                  $assembly->assembly_level(),     $assembly->base_count(),
                  $assembly->dbID() ] );
-  $self->_store_sequences($assembly);
   return;
 }
 

--- a/modules/Bio/EnsEMBL/MetaData/DBSQL/GenomeInfoAdaptor.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DBSQL/GenomeInfoAdaptor.pm
@@ -293,10 +293,20 @@ sub store {
             -SQL => "select genome_id from genome where data_release_id=? and assembly_id=? and division_id=?",
             -PARAMS => [ $genome->data_release()->dbID(),
                         $genome->assembly()->dbID(), $self->_get_division_id($genome->division()) ] ) };
-
         if ( defined $dbID ) {
-          $genome->dbID($dbID);
-          $genome->adaptor($self);
+          #Check if the assembly sequences have changed, e.g: new MT, scaffold...
+          my $release_genomes = $self->fetch_by_name($genome->{organism}->{name});
+          foreach my $release_genome (@{$release_genomes}){
+            if (defined $release_genome and ($release_genome->division() eq $genome->division())){
+              if ($release_genome->base_count() ne $genome->base_count()){
+                $dbID='';
+              }
+              else{
+                $genome->dbID($dbID);
+                $genome->adaptor($self);
+              }
+            }
+          }
         }
       }
 

--- a/modules/t/test-genome-DBs/multi/empty_metadata/table.sql
+++ b/modules/t/test-genome-DBs/multi/empty_metadata/table.sql
@@ -31,7 +31,7 @@ CREATE TABLE `assembly` (
   `assembly_level` varchar(50) NOT NULL,
   `base_count` bigint(20) unsigned NOT NULL,
   PRIMARY KEY (`assembly_id`),
-  UNIQUE KEY `assembly_accession_idx` (`assembly_accession`,`assembly_default`)
+  UNIQUE KEY `assembly_idx` (`assembly_accession`,`assembly_default`,`base_count`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/sql/patch_13022019_q.sql
+++ b/sql/patch_13022019_q.sql
@@ -1,0 +1,21 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2019] EMBL-European Bioinformatics Institute
+-- 
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+-- 
+--      http://www.apache.org/licenses/LICENSE-2.0
+-- 
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+# patch_13022019_q
+#
+# Title: Allow organism to have same assembly default, accession but different base_count.
+#
+# Description: Remove the assembly_idx on assembly_default and assembly_accession, create new assembly_idx including base_count. The assembly can be the same but the underlying sequence have changed (e.g: new MT, new scaffolds..)
+DROP INDEX assembly_idx on assembly;
+ALTER TABLE assembly ADD UNIQUE assembly_idx (assembly_accession,assembly_default,base_count);

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -31,7 +31,7 @@ CREATE TABLE `assembly` (
   `assembly_level` varchar(50) NOT NULL,
   `base_count` bigint(20) unsigned NOT NULL,
   PRIMARY KEY (`assembly_id`),
-  UNIQUE KEY `assembly_accession_idx` (`assembly_accession`,`assembly_default`)
+  UNIQUE KEY `assembly_idx` (`assembly_accession`,`assembly_default`,`base_count`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 


### PR DESCRIPTION
Adding base_count to assembly index. This is to cover edge cases when a MT sequence or scaffold are added to an assembly after this assembly was released. In these cases the sum of seq_region lengh will change. Also fixing assembly index name in table.sql and test.
Created two new method in Base.pm called check_assembly_update and check_genebuild_update. These methods are now used by the metadataUpdater, report_genomes script and CheckAssemblyGeneset for consistency. We are also doing an extra check on base_count for assembly change to pick up addition of MT or Scaffolds to an existing assembly. GenomeAssemblyInfoAdaptor has been updated to check base_count as well if assembly meta key are the same between two releases. GenomeInfoAdaptor store method will now check base_count when a genome already exist with same assembly meta key, if the base_count if different, the previosu genome will be cleaned up and we will treat this situation as a new assembly (delete previous db as each team will have to re-submit new ones).