### PR TITLE
Remove default divisions

### DIFF
--- a/modules/Bio/EnsEMBL/MetaData/Pipeline/MetadataDumps_conf.pm
+++ b/modules/Bio/EnsEMBL/MetaData/Pipeline/MetadataDumps_conf.pm
@@ -43,7 +43,7 @@ sub default_options {
            'port'      => undef,
            'host'      => undef,
            'dbname'      => 'ensembl_metadata',
-           'division'      => ['metazoa','plants','fungi','protists','bacteria','vertebrates'],
+           'division'      => [],
            'base_dir'     => getcwd,
            'release'  => undef,
            'pipeline_name' => 'metadata_dumps_'.$self->o('release'), 


### PR DESCRIPTION
When a hive pipeline config is parsed, for array-valued parameters anything specified on the command line to init_pipeline.pl is added to the default values that are already there, there is no overwriting. So you would always be running for all divisions, whatever -division parameter you supply.