### PR TITLE
When an assembly patch is updated for human and mouse, the assembly_n…

### DIFF
--- a/misc_scripts/report_genomes.pl
+++ b/misc_scripts/report_genomes.pl
@@ -219,13 +219,13 @@ foreach my $div (@{$opts->{divisions}}){
           my $updated_assembly=check_assembly_update($genome->{genome},$prev_genome->{genome});
           my $updated_genebuild=check_genebuild_update($genome->{genome},$prev_genome->{genome});
           if ($updated_assembly) {
-            # Report asssembly_default change
-            if ($genome->{assembly} ne $prev_genome->{assembly}){
-              $report_updates->{$division}->{updated_assemblies}->{$genome->{name}} = {name=>$genome->{name},assembly=>$genome->{assembly},old_assembly=>$prev_genome->{assembly},database=>$genome->{database},species_id=>$genome->{species_id}};
-            }
-            # or report the asssembly_name meta key when we have new patches for human or mouse
-            else{
+            # report the asssembly_name meta key when we have new patches for human or mouse
+            if ($updated_assembly == 2){
               $report_updates->{$division}->{updated_assemblies}->{$genome->{name}} = {name=>$genome->{name},assembly=>$genome->{assembly_name},old_assembly=>$prev_genome->{assembly_name},database=>$genome->{database},species_id=>$genome->{species_id}};
+            }
+            # Report asssembly_default change
+            else{
+              $report_updates->{$division}->{updated_assemblies}->{$genome->{name}} = {name=>$genome->{name},assembly=>$genome->{assembly},old_assembly=>$prev_genome->{assembly},database=>$genome->{database},species_id=>$genome->{species_id}};
             }
           } elsif ($updated_genebuild) {
             $report_updates->{$division}->{updated_annotations}->{$genome->{name}} = {name=>$genome->{name},assembly=>$genome->{assembly},new_genebuild=>$genome->{genebuild},old_genebuild=>$prev_genome->{genebuild},database=>$genome->{database},species_id=>$genome->{species_id}};

--- a/misc_scripts/report_genomes.pl
+++ b/misc_scripts/report_genomes.pl
@@ -219,7 +219,14 @@ foreach my $div (@{$opts->{divisions}}){
           my $updated_assembly=check_assembly_update($genome->{genome},$prev_genome->{genome});
           my $updated_genebuild=check_genebuild_update($genome->{genome},$prev_genome->{genome});
           if ($updated_assembly) {
-            $report_updates->{$division}->{updated_assemblies}->{$genome->{name}} = {name=>$genome->{name},assembly=>$genome->{assembly},old_assembly=>$prev_genome->{assembly},database=>$genome->{database},species_id=>$genome->{species_id}};
+            # Report asssembly_default change
+            if ($genome->{assembly} ne $prev_genome->{assembly}){
+              $report_updates->{$division}->{updated_assemblies}->{$genome->{name}} = {name=>$genome->{name},assembly=>$genome->{assembly},old_assembly=>$prev_genome->{assembly},database=>$genome->{database},species_id=>$genome->{species_id}};
+            }
+            # or report the asssembly_name meta key when we have new patches for human or mouse
+            else{
+              $report_updates->{$division}->{updated_assemblies}->{$genome->{name}} = {name=>$genome->{name},assembly=>$genome->{assembly_name},old_assembly=>$prev_genome->{assembly_name},database=>$genome->{database},species_id=>$genome->{species_id}};
+            }
           } elsif ($updated_genebuild) {
             $report_updates->{$division}->{updated_annotations}->{$genome->{name}} = {name=>$genome->{name},assembly=>$genome->{assembly},new_genebuild=>$genome->{genebuild},old_genebuild=>$prev_genome->{genebuild},database=>$genome->{database},species_id=>$genome->{species_id}};
           }
@@ -387,6 +394,7 @@ sub get_genomes {
       genome=>$genome,
       name=>$genome->name(),
       assembly=>$genome->assembly_default(),
+      assembly_name=>$genome->assembly_name(),
       display_name=>$genome->display_name(),
       genebuild=>$genome->genebuild(),
       database=>$genome->dbname(),

--- a/modules/Bio/EnsEMBL/MetaData/Base.pm
+++ b/modules/Bio/EnsEMBL/MetaData/Base.pm
@@ -176,10 +176,10 @@ sub check_assembly_update {
   # Check assembly default meta key
   $updated_assembly = 1 if $genome->assembly_default() ne $prev_genome->assembly_default();
   # Also check the assembly name meta key for patches update. Mainly affects human and mouse
-  $updated_assembly = 1 if $genome->assembly_name() ne $prev_genome->assembly_name();
+  $updated_assembly = 2 if $genome->assembly_name() ne $prev_genome->assembly_name();
   # Check base_count value which is the sum of lenght of seq_region. If new sequences have been added to the assembly, this will change.
   # We can pick up new MT or scaffolds
-  $updated_assembly = 1 if $genome->base_count() ne $prev_genome->base_count();
+  $updated_assembly = 3 if $genome->base_count() ne $prev_genome->base_count();
   return $updated_assembly;
 }
 

--- a/modules/Bio/EnsEMBL/MetaData/Base.pm
+++ b/modules/Bio/EnsEMBL/MetaData/Base.pm
@@ -175,6 +175,8 @@ sub check_assembly_update {
   my $updated_assembly=0;
   # Check assembly default meta key
   $updated_assembly = 1 if $genome->assembly_default() ne $prev_genome->assembly_default();
+  # Also check the assembly name meta key for patches update. Mainly affects human and mouse
+  $updated_assembly = 1 if $genome->assembly_name() ne $prev_genome->assembly_name();
   # Check base_count value which is the sum of lenght of seq_region. If new sequences have been added to the assembly, this will change.
   # We can pick up new MT or scaffolds
   $updated_assembly = 1 if $genome->base_count() ne $prev_genome->base_count();

--- a/modules/Bio/EnsEMBL/MetaData/DBSQL/GenomeInfoAdaptor.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DBSQL/GenomeInfoAdaptor.pm
@@ -321,6 +321,14 @@ sub store {
             -SQL => "select genome_id from genome where data_release_id=? and assembly_id=? and division_id=?",
             -PARAMS => [ $genome->data_release()->dbID(),
                         $genome->assembly()->dbID(), $self->_get_division_id($genome->division()) ] ) };
+        # The genome migh have somekind of changes in the assembly, e.g: new patches for human or renaming. In this case check if we have existing data for this genome.
+        if ( !defined $dbID ) {
+          ($dbID) = @{
+          $self->dbc()->sql_helper()->execute_simple(
+            -SQL => "select genome_id from genome join organism USING (organism_id) where data_release_id=? and division_id=? and name=?",
+            -PARAMS => [ $genome->data_release()->dbID(),
+                         $self->_get_division_id($genome->division()),$genome->name() ] ) };
+        }
         my $release_genome = $self->fetch_by_dbID($dbID);
         if (defined $release_genome){
           $self->clear_genome($release_genome);


### PR DESCRIPTION
…ame will change from e.g: GRCh38.p12 to GRCh38.p13. We should spot this and flag it as an assembly update since we need to re-dump DNA and things like that. I've update the report_genomes script to properly report patches update. There was an edge case bug in the case since assembly_name has been updated but the base_count is the same, so now making to retrieve the species and cleaning up