### PR TITLE
By looking at all the non-vert and vert job for release 100, only met…

### DIFF
--- a/modules/Bio/EnsEMBL/MetaData/Pipeline/MetadataUpdater_conf.pm
+++ b/modules/Bio/EnsEMBL/MetaData/Pipeline/MetadataUpdater_conf.pm
@@ -29,7 +29,8 @@ use base ('Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf');  # All Hive datab
 sub resource_classes {
     my ($self) = @_;
     return { 'default' => { 'LSF' => '-q production-rh74'},
-         'himem' => { 'LSF' => '-q production-rh74 -M  20000 -R "rusage[mem=20000]"' } };
+         '10GB' => { 'LSF' => '-q production-rh74 -M 10000 -R "rusage[mem=10000]"' },
+         '20GB' => { 'LSF' => '-q production-rh74 -M 20000 -R "rusage[mem=20000]"' } };
 }
 
 sub default_options {
@@ -90,7 +91,7 @@ sub pipeline_analyses {
             -analysis_capacity => 30,
             -parameters => {
              },
-            -rc_name => 'himem',
+            -rc_name => '20GB',
             -flow_into     => {
                    2 => [ '?table_name=result']
             },
@@ -103,7 +104,7 @@ sub pipeline_analyses {
             -wait_for      => [ 'metadata_updater_core' ],
             -parameters => {
              },
-            -rc_name => 'himem',
+            -rc_name => '10GB',
             -flow_into     => {
                    2 => [ '?table_name=result']
             },
@@ -116,7 +117,7 @@ sub pipeline_analyses {
             -wait_for      => [ 'metadata_updater_core', 'metadata_updater_other' ],
             -parameters => {
              },
-            -rc_name => 'default',
+            -rc_name => '10GB',
             -flow_into     => {
                    2 => [ '?table_name=result']
             },

--- a/modules/Bio/EnsEMBL/MetaData/Pipeline/MetadataUpdater_conf.pm
+++ b/modules/Bio/EnsEMBL/MetaData/Pipeline/MetadataUpdater_conf.pm
@@ -29,8 +29,8 @@ use base ('Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf');  # All Hive datab
 sub resource_classes {
     my ($self) = @_;
     return { 'default' => { 'LSF' => '-q production-rh74'},
-         '10GB' => { 'LSF' => '-q production-rh74 -M 10000 -R "rusage[mem=10000]"' },
-         '20GB' => { 'LSF' => '-q production-rh74 -M 20000 -R "rusage[mem=20000]"' } };
+         '1GB' => { 'LSF' => '-q production-rh74 -M 1000 -R "rusage[mem=1000]"' },
+         '2GB' => { 'LSF' => '-q production-rh74 -M 2000 -R "rusage[mem=2000]"' } };
 }
 
 sub default_options {
@@ -91,7 +91,7 @@ sub pipeline_analyses {
             -analysis_capacity => 30,
             -parameters => {
              },
-            -rc_name => '20GB',
+            -rc_name => '2GB',
             -flow_into     => {
                    2 => [ '?table_name=result']
             },
@@ -104,7 +104,7 @@ sub pipeline_analyses {
             -wait_for      => [ 'metadata_updater_core' ],
             -parameters => {
              },
-            -rc_name => '10GB',
+            -rc_name => '1GB',
             -flow_into     => {
                    2 => [ '?table_name=result']
             },
@@ -117,7 +117,7 @@ sub pipeline_analyses {
             -wait_for      => [ 'metadata_updater_core', 'metadata_updater_other' ],
             -parameters => {
              },
-            -rc_name => '10GB',
+            -rc_name => '1GB',
             -flow_into     => {
                    2 => [ '?table_name=result']
             },


### PR DESCRIPTION
…adata_updater_core needs 2GB of memory, the other analysis will have enough with 1GB. metadata_updater_compara is tight with the default.