### PR TITLE
The Bacteria deadlock seems to have been caused by having two unique …

### DIFF
--- a/modules/t/test-genome-DBs/multi/empty_metadata/table.sql
+++ b/modules/t/test-genome-DBs/multi/empty_metadata/table.sql
@@ -277,8 +277,7 @@ CREATE TABLE `genome_database` (
   `species_id` int(10) unsigned NOT NULL,
   `type` enum('core','funcgen','variation','otherfeatures','rnaseq','cdna','vega') DEFAULT NULL,
   PRIMARY KEY (`genome_database_id`),
-  UNIQUE KEY `id_dbname` (`genome_id`,`dbname`),
-  UNIQUE KEY `dbname_species_id` (`dbname`,`species_id`),
+  UNIQUE KEY `genome_db_species` (`genome_id`,`dbname`,`species_id`),
   CONSTRAINT `genome_database_ibfk_1` FOREIGN KEY (`genome_id`) REFERENCES `genome` (`genome_id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/sql/patch_11022020_r.sql
+++ b/sql/patch_11022020_r.sql
@@ -1,0 +1,24 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- 
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+-- 
+--      http://www.apache.org/licenses/LICENSE-2.0
+-- 
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+# patch_11022020_r
+#
+# Title: Group unique keys genome_database table
+#
+# Description: Group the two unique keys from genome_database in one to avoid deadlocks
+ALTER TABLE genome_database DROP FOREIGN KEY genome_database_ibfk_1;
+DROP INDEX id_dbname on genome_database;
+DROP INDEX dbname_species_id on genome_database;
+ALTER TABLE genome_database ADD UNIQUE genome_db_species (genome_id,dbname,species_id);
+ALTER TABLE genome_database ADD CONSTRAINT genome_database_ibfk_1 FOREIGN KEY (genome_id) REFERENCES genome (genome_id) ON DELETE CASCADE;

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -277,8 +277,7 @@ CREATE TABLE `genome_database` (
   `species_id` int(10) unsigned NOT NULL,
   `type` enum('core','funcgen','variation','otherfeatures','rnaseq','cdna','vega') DEFAULT NULL,
   PRIMARY KEY (`genome_database_id`),
-  UNIQUE KEY `id_dbname` (`genome_id`,`dbname`),
-  UNIQUE KEY `dbname_species_id` (`dbname`,`species_id`),
+  UNIQUE KEY `genome_db_species` (`genome_id`,`dbname`,`species_id`),
   CONSTRAINT `genome_database_ibfk_1` FOREIGN KEY (`genome_id`) REFERENCES `genome` (`genome_id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;


### PR DESCRIPTION
…indexes. Grouping them into one seems to have resolved the deadlocks in my test load of all the Bacteria databases.