### PR TITLE
Fixing a deadlock issue randomly happening when loading collection da…

### DIFF
--- a/modules/Bio/EnsEMBL/MetaData/DBSQL/GenomeInfoAdaptor.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DBSQL/GenomeInfoAdaptor.pm
@@ -272,6 +272,8 @@ sub store {
     -RETRY => 3,
     -PAUSE => 2,
     -CALLBACK => sub {
+      $self->dbc()->sql_helper()->execute_update(
+        -SQL => q/SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED/);
       if ( !defined $genome->data_release() ) {
         $genome->data_release( $self->data_release() );
       }
@@ -393,6 +395,8 @@ sub update {
     -RETRY => 3,
     -PAUSE => 2,
     -CALLBACK => sub {
+      $self->dbc()->sql_helper()->execute_update(
+        -SQL => q/SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED/);
       if ( !defined $genome->dbID() ) {
         croak "Cannot update an object that has not already been stored";
       }


### PR DESCRIPTION
…tabases, the issue is caused by the unique index on genome_id,dbname,species_id on genome_database.This is because collection databases will share the same db name but different species_id. By default InnoDB transactions is using REPEATABLE READ which mean that every lock acquired during a transaction is held for the duration of the transaction. This change enable READ COMMITTED which mean that the locks that did not match the scan are released after the STATEMENT completes. This change made on the transaction allow us to keep the unique index and avoid deadlocks. This was discussed and approved by DBA. This change could also be made on the server level if required.
More info here: https://www.percona.com/blog/2013/12/12/one-more-innodb-gap-lock-to-avoid/ and here: https://www.percona.com/blog/2012/08/28/differences-between-read-committed-and-repeatable-read-transaction-isolation-levels/