### PR TITLE
When release is not specified on the command line and if both ensembl…

### DIFF
--- a/modules/Bio/EnsEMBL/MetaData/DBSQL/DataReleaseInfoAdaptor.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DBSQL/DataReleaseInfoAdaptor.pm
@@ -195,7 +195,7 @@ sub fetch_by_ensembl_release {
     $ens_release = $self->_first_element(
              $self->_fetch_generic(
                _get_base_sql() .
-                 ' where ensembl_version=?',
+                 ' where ensembl_version=? order by ensembl_genomes_version desc',
                [$release] ) );
   }
   return $ens_release;


### PR DESCRIPTION
… and eg release exists and we have multiple ensembl releases order by eg releases. This is mainly to help us assign the right release in Rapid release but will also help external groups