### PR TITLE
Return the latest assembly, if more than one entry exists

### DIFF
--- a/modules/Bio/EnsEMBL/MetaData/DBSQL/GenomeAssemblyInfoAdaptor.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DBSQL/GenomeAssemblyInfoAdaptor.pm
@@ -195,7 +195,7 @@ sub fetch_all_by_sequence_accession_unversioned {
   return
     $self->_fetch_generic(
     $self->_get_base_sql() .
-' where assembly_id in (select distinct(assembly_id) from assembly_sequence where acc like ? or name like ?)',
+' where assembly_id in (select distinct(assembly_id) from assembly_sequence where acc like ? or name like ?) order by dbID desc',
     [ $id . '.%', $id . '.%' ],
     $keen );
 }
@@ -215,7 +215,7 @@ sub fetch_all_by_sequence_accession_versioned {
   return
     $self->_fetch_generic(
     $self->_get_base_sql() .
-' where assembly_id in (select distinct(assembly_id) from assembly_sequence where acc=? or name=?)',
+' where assembly_id in (select distinct(assembly_id) from assembly_sequence where acc=? or name=?) order by dbID desc',
     [ $id, $id ],
     $keen );
 }
@@ -235,7 +235,7 @@ sub fetch_by_assembly_accession {
   return
     $self->_first_element(
                          $self->_fetch_generic(
-                           $self->_get_base_sql . ' where assembly_accession=?',
+                           $self->_get_base_sql . ' where assembly_accession=? order by dbID desc',
                            [$id], $keen ) );
 
 }
@@ -254,7 +254,7 @@ sub fetch_all_by_assembly_set_chain {
   my ( $self, $id, $keen ) = @_;
   return
     $self->_fetch_generic(
-                      $self->_get_base_sql . ' where assembly_accession like ?',
+                      $self->_get_base_sql . ' where assembly_accession like ? order by dbID desc',
                       [ $id . '.%' ], $keen );
 }
 =head1 INTERNAL METHODS


### PR DESCRIPTION
Return the latest assembly, if more than one entry exists for the same assembly_accession value. For methods that return a list of assemblies, sort in descending order.
https://www.ebi.ac.uk/panda/jira/browse/ENSPROD-6588