### PR TITLE
Merge master to 105

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.xml
 *.out
 .*
+modules/t/MultiTestDB.conf

--- a/misc_scripts/dump_metadata.pl
+++ b/misc_scripts/dump_metadata.pl
@@ -2,7 +2,7 @@
 
 =head1 LICENSE
 
-Copyright [2009-2020] EMBL-European Bioinformatics Institute
+Copyright [2009-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc_scripts/example_scripts/fetch_by_accession.pl
+++ b/misc_scripts/example_scripts/fetch_by_accession.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 =head1 LICENSE
- Copyright [2009-2020] EMBL-European Bioinformatics Institute
+ Copyright [2009-2021] EMBL-European Bioinformatics Institute
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/misc_scripts/example_scripts/fetch_by_accession_using_db.pl
+++ b/misc_scripts/example_scripts/fetch_by_accession_using_db.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 =head1 LICENSE
- Copyright [2009-2020] EMBL-European Bioinformatics Institute
+ Copyright [2009-2021] EMBL-European Bioinformatics Institute
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/misc_scripts/example_scripts/fetch_by_assembly.pl
+++ b/misc_scripts/example_scripts/fetch_by_assembly.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 =head1 LICENSE
- Copyright [2009-2020] EMBL-European Bioinformatics Institute
+ Copyright [2009-2021] EMBL-European Bioinformatics Institute
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/misc_scripts/example_scripts/fetch_by_name.pl
+++ b/misc_scripts/example_scripts/fetch_by_name.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 =head1 LICENSE
- Copyright [2009-2020] EMBL-European Bioinformatics Institute
+ Copyright [2009-2021] EMBL-European Bioinformatics Institute
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/misc_scripts/example_scripts/fetch_by_pattern.pl
+++ b/misc_scripts/example_scripts/fetch_by_pattern.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 =head1 LICENSE
- Copyright [2009-2020] EMBL-European Bioinformatics Institute
+ Copyright [2009-2021] EMBL-European Bioinformatics Institute
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/misc_scripts/example_scripts/fetch_by_tax_node.pl
+++ b/misc_scripts/example_scripts/fetch_by_tax_node.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 =head1 LICENSE
- Copyright [2009-2020] EMBL-European Bioinformatics Institute
+ Copyright [2009-2021] EMBL-European Bioinformatics Institute
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/misc_scripts/example_scripts/fetch_by_taxid.pl
+++ b/misc_scripts/example_scripts/fetch_by_taxid.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 =head1 LICENSE
- Copyright [2009-2020] EMBL-European Bioinformatics Institute
+ Copyright [2009-2021] EMBL-European Bioinformatics Institute
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/misc_scripts/example_scripts/find_all_eg_genomes.pl
+++ b/misc_scripts/example_scripts/find_all_eg_genomes.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 =head1 LICENSE
- Copyright [2009-2020] EMBL-European Bioinformatics Institute
+ Copyright [2009-2021] EMBL-European Bioinformatics Institute
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/misc_scripts/example_scripts/find_all_genomes.pl
+++ b/misc_scripts/example_scripts/find_all_genomes.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 =head1 LICENSE
- Copyright [2009-2020] EMBL-European Bioinformatics Institute
+ Copyright [2009-2021] EMBL-European Bioinformatics Institute
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/misc_scripts/example_scripts/find_all_genomes_e83.pl
+++ b/misc_scripts/example_scripts/find_all_genomes_e83.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 =head1 LICENSE
- Copyright [2009-2020] EMBL-European Bioinformatics Institute
+ Copyright [2009-2021] EMBL-European Bioinformatics Institute
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/misc_scripts/example_scripts/find_all_genomes_for_compara.pl
+++ b/misc_scripts/example_scripts/find_all_genomes_for_compara.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 =head1 LICENSE
- Copyright [2009-2020] EMBL-European Bioinformatics Institute
+ Copyright [2009-2021] EMBL-European Bioinformatics Institute
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/misc_scripts/example_scripts/find_all_genomes_for_division.pl
+++ b/misc_scripts/example_scripts/find_all_genomes_for_division.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 =head1 LICENSE
- Copyright [2009-2020] EMBL-European Bioinformatics Institute
+ Copyright [2009-2021] EMBL-European Bioinformatics Institute
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/misc_scripts/example_scripts/find_all_genomes_for_taxon.pl
+++ b/misc_scripts/example_scripts/find_all_genomes_for_taxon.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 =head1 LICENSE
- Copyright [2009-2020] EMBL-European Bioinformatics Institute
+ Copyright [2009-2021] EMBL-European Bioinformatics Institute
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/misc_scripts/example_scripts/find_all_genomes_with_variation.pl
+++ b/misc_scripts/example_scripts/find_all_genomes_with_variation.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 =head1 LICENSE
- Copyright [2009-2020] EMBL-European Bioinformatics Institute
+ Copyright [2009-2021] EMBL-European Bioinformatics Institute
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/misc_scripts/get_list_databases_for_division.pl
+++ b/misc_scripts/get_list_databases_for_division.pl
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc_scripts/get_list_genomes_for_division.pl
+++ b/misc_scripts/get_list_genomes_for_division.pl
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc_scripts/metadata_json_loader.pl
+++ b/misc_scripts/metadata_json_loader.pl
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright [2016-2020] EMBL-European Bioinformatics Institute
+# Copyright [2016-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc_scripts/metadata_updater.pl
+++ b/misc_scripts/metadata_updater.pl
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright [2016-2020] EMBL-European Bioinformatics Institute
+# Copyright [2016-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/LookUp.pm
+++ b/modules/Bio/EnsEMBL/LookUp.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2009-2020] EMBL-European Bioinformatics Institute
+Copyright [2009-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/LookUp/LocalLookUp.pm
+++ b/modules/Bio/EnsEMBL/LookUp/LocalLookUp.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2009-2020] EMBL-European Bioinformatics Institute
+Copyright [2009-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/LookUp/RemoteLookUp.pm
+++ b/modules/Bio/EnsEMBL/LookUp/RemoteLookUp.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2009-2020] EMBL-European Bioinformatics Institute
+Copyright [2009-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/AnnotationAnalyzer.pm
+++ b/modules/Bio/EnsEMBL/MetaData/AnnotationAnalyzer.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2009-2020] EMBL-European Bioinformatics Institute
+Copyright [2009-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/Base.pm
+++ b/modules/Bio/EnsEMBL/MetaData/Base.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [1999-2020] EMBL-European Bioinformatics Institute
+Copyright [1999-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/BaseInfo.pm
+++ b/modules/Bio/EnsEMBL/MetaData/BaseInfo.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [1999-2020] EMBL-European Bioinformatics Institute
+Copyright [1999-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/DBSQL/BaseInfoAdaptor.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DBSQL/BaseInfoAdaptor.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [1999-2020] EMBL-European Bioinformatics Institute
+Copyright [1999-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/DBSQL/DataReleaseInfoAdaptor.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DBSQL/DataReleaseInfoAdaptor.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [1999-2020] EMBL-European Bioinformatics Institute
+Copyright [1999-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/DBSQL/DatabaseInfoAdaptor.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DBSQL/DatabaseInfoAdaptor.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [1999-2020] EMBL-European Bioinformatics Institute
+Copyright [1999-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/DBSQL/EventInfoAdaptor.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DBSQL/EventInfoAdaptor.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [1999-2020] EMBL-European Bioinformatics Institute
+Copyright [1999-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/DBSQL/GenomeAssemblyInfoAdaptor.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DBSQL/GenomeAssemblyInfoAdaptor.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [1999-2020] EMBL-European Bioinformatics Institute
+Copyright [1999-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -195,7 +195,7 @@ sub fetch_all_by_sequence_accession_unversioned {
   return
     $self->_fetch_generic(
     $self->_get_base_sql() .
-' where assembly_id in (select distinct(assembly_id) from assembly_sequence where acc like ? or name like ?)',
+' where assembly_id in (select distinct(assembly_id) from assembly_sequence where acc like ? or name like ?) order by dbID desc',
     [ $id . '.%', $id . '.%' ],
     $keen );
 }
@@ -215,7 +215,7 @@ sub fetch_all_by_sequence_accession_versioned {
   return
     $self->_fetch_generic(
     $self->_get_base_sql() .
-' where assembly_id in (select distinct(assembly_id) from assembly_sequence where acc=? or name=?)',
+' where assembly_id in (select distinct(assembly_id) from assembly_sequence where acc=? or name=?) order by dbID desc',
     [ $id, $id ],
     $keen );
 }
@@ -235,7 +235,7 @@ sub fetch_by_assembly_accession {
   return
     $self->_first_element(
                          $self->_fetch_generic(
-                           $self->_get_base_sql . ' where assembly_accession=?',
+                           $self->_get_base_sql . ' where assembly_accession=? order by dbID desc',
                            [$id], $keen ) );
 
 }
@@ -254,7 +254,7 @@ sub fetch_all_by_assembly_set_chain {
   my ( $self, $id, $keen ) = @_;
   return
     $self->_fetch_generic(
-                      $self->_get_base_sql . ' where assembly_accession like ?',
+                      $self->_get_base_sql . ' where assembly_accession like ? order by dbID desc',
                       [ $id . '.%' ], $keen );
 }
 =head1 INTERNAL METHODS

--- a/modules/Bio/EnsEMBL/MetaData/DBSQL/GenomeComparaInfoAdaptor.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DBSQL/GenomeComparaInfoAdaptor.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [1999-2020] EMBL-European Bioinformatics Institute
+Copyright [1999-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/DBSQL/GenomeInfoAdaptor.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DBSQL/GenomeInfoAdaptor.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [1999-2020] EMBL-European Bioinformatics Institute
+Copyright [1999-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/DBSQL/MetaDataDBAdaptor.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DBSQL/MetaDataDBAdaptor.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2009-2020] EMBL-European Bioinformatics Institute
+Copyright [2009-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/DBSQL/MySQLServerProvider.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DBSQL/MySQLServerProvider.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2009-2020] EMBL-European Bioinformatics Institute
+Copyright [2009-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/DBSQL/ParameterMySQLServerProvider.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DBSQL/ParameterMySQLServerProvider.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2009-2020] EMBL-European Bioinformatics Institute
+Copyright [2009-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/DataReleaseInfo.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DataReleaseInfo.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [1999-2020] EMBL-European Bioinformatics Institute
+Copyright [1999-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/DatabaseInfo.pm
+++ b/modules/Bio/EnsEMBL/MetaData/DatabaseInfo.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [1999-2020] EMBL-European Bioinformatics Institute
+Copyright [1999-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -218,13 +218,13 @@ sub to_string {
 
 sub _parse_type {
   my ($dbname) = @_;
-  if ( $dbname =~ m/mart/ ) {
+  if ( $dbname =~ m/_mart_/ ) {
     return 'mart';
   }
-  elsif ( $dbname =~ m/ontology/ ) {
+  elsif ( $dbname =~ m/_ontology(?:_|$)/ ) {
     return 'ontology';
   }
-  elsif ( $dbname =~ m/ancestral/ ){
+  elsif ( $dbname =~ m/_ancestral_/ ){
     return 'other';
   }
   else {

--- a/modules/Bio/EnsEMBL/MetaData/EventInfo.pm
+++ b/modules/Bio/EnsEMBL/MetaData/EventInfo.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [1999-2020] EMBL-European Bioinformatics Institute
+Copyright [1999-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/GenomeAssemblyInfo.pm
+++ b/modules/Bio/EnsEMBL/MetaData/GenomeAssemblyInfo.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [1999-2020] EMBL-European Bioinformatics Institute
+Copyright [1999-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/GenomeComparaInfo.pm
+++ b/modules/Bio/EnsEMBL/MetaData/GenomeComparaInfo.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [1999-2020] EMBL-European Bioinformatics Institute
+Copyright [1999-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/GenomeInfo.pm
+++ b/modules/Bio/EnsEMBL/MetaData/GenomeInfo.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [1999-2020] EMBL-European Bioinformatics Institute
+Copyright [1999-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/GenomeOrganismInfo.pm
+++ b/modules/Bio/EnsEMBL/MetaData/GenomeOrganismInfo.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [1999-2020] EMBL-European Bioinformatics Institute
+Copyright [1999-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/MetaDataDumper.pm
+++ b/modules/Bio/EnsEMBL/MetaData/MetaDataDumper.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2009-2020] EMBL-European Bioinformatics Institute
+Copyright [2009-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/MetaDataDumper/JsonMetaDataDumper.pm
+++ b/modules/Bio/EnsEMBL/MetaData/MetaDataDumper/JsonMetaDataDumper.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2009-2020] EMBL-European Bioinformatics Institute
+Copyright [2009-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/MetaDataDumper/TT2MetaDataDumper.pm
+++ b/modules/Bio/EnsEMBL/MetaData/MetaDataDumper/TT2MetaDataDumper.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2009-2020] EMBL-European Bioinformatics Institute
+Copyright [2009-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/MetaDataDumper/TextMetaDataDumper.pm
+++ b/modules/Bio/EnsEMBL/MetaData/MetaDataDumper/TextMetaDataDumper.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2009-2020] EMBL-European Bioinformatics Institute
+Copyright [2009-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ sub start {
 	print $fh '#'
 	  .
 	  join("\t",
-		   qw(name species division taxonomy_id assembly assembly_accession genebuild variation pan_compara peptide_compara genome_alignments other_alignments core_db species_id)
+		   qw(name species division taxonomy_id assembly assembly_accession genebuild variation microarray pan_compara peptide_compara genome_alignments other_alignments core_db species_id)
 	  ) .
 	  "\n";
   }

--- a/modules/Bio/EnsEMBL/MetaData/MetaDataDumper/UniProtReportDumper.pm
+++ b/modules/Bio/EnsEMBL/MetaData/MetaDataDumper/UniProtReportDumper.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2009-2020] EMBL-European Bioinformatics Institute
+Copyright [2009-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/MetaDataDumper/XMLMetaDataDumper.pm
+++ b/modules/Bio/EnsEMBL/MetaData/MetaDataDumper/XMLMetaDataDumper.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2009-2020] EMBL-European Bioinformatics Institute
+Copyright [2009-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/MetaDataProcessor.pm
+++ b/modules/Bio/EnsEMBL/MetaData/MetaDataProcessor.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [1999-2020] EMBL-European Bioinformatics Institute
+Copyright [1999-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/MetadataUpdater.pm
+++ b/modules/Bio/EnsEMBL/MetaData/MetadataUpdater.pm
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2020] EMBL-European Bioinformatics Institute
+# Copyright [2016-2021] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -413,7 +413,7 @@ sub process_release_database {
 #Check pan division databases like ontology db, ncbi_taxonomy, ensembl_metadata,...
 sub check_pan_databases {
   my ($database_name) = @_;
-  return $database_name =~ m/(ontology|ensembl_metadata|ensembl_website|ncbi_taxonomy|ensembl_accounts|ensembl_archive|ensembl_stable_ids|ensemblgenomes_stable_ids|ensembl_production)/;
+  return $database_name =~ m/(ontology|ensembl_metadata|ensembl_website|ncbi_taxonomy|ensembl_accounts|ensembl_archive|ensembl_stable_ids|ensemblgenomes_stable_ids|ensembl_production|ensembl_autocomplete)/;
 }
 
 #Subroutine to add or force update a species database

--- a/modules/Bio/EnsEMBL/MetaData/Pipeline/MetadataDumps_conf.pm
+++ b/modules/Bio/EnsEMBL/MetaData/Pipeline/MetadataDumps_conf.pm
@@ -7,7 +7,7 @@
 
 =head1 LICENSE
     Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-    Copyright [2016-2020] EMBL-European Bioinformatics Institute
+    Copyright [2016-2021] EMBL-European Bioinformatics Institute
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
          http://www.apache.org/licenses/LICENSE-2.0
@@ -31,8 +31,8 @@ use Cwd;
 sub resource_classes {
   my ($self) = @_;
   return { 
-	  'default' => { 'LSF' => '-q production-rh74' },
-	  'himem' => { 'LSF' => '-q production-rh74 -M 20000 -R "rusage[mem=20000]"' }
+	  'default' => { 'LSF' => '-q production' },
+	  'himem' => { 'LSF' => '-q production -M 20000 -R "rusage[mem=20000]"' }
 	 };
 }
 

--- a/modules/Bio/EnsEMBL/MetaData/Pipeline/MetadataUpdaterHive.pm
+++ b/modules/Bio/EnsEMBL/MetaData/Pipeline/MetadataUpdaterHive.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2020] EMBL-European Bioinformatics Institute
+Copyright [2016-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/Pipeline/MetadataUpdaterHiveProcessDb.pm
+++ b/modules/Bio/EnsEMBL/MetaData/Pipeline/MetadataUpdaterHiveProcessDb.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2020] EMBL-European Bioinformatics Institute
+Copyright [2016-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MetaData/Pipeline/MetadataUpdater_conf.pm
+++ b/modules/Bio/EnsEMBL/MetaData/Pipeline/MetadataUpdater_conf.pm
@@ -7,7 +7,7 @@
 
 =head1 LICENSE
     Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-    Copyright [2016-2020] EMBL-European Bioinformatics Institute
+    Copyright [2016-2021] EMBL-European Bioinformatics Institute
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
          http://www.apache.org/licenses/LICENSE-2.0
@@ -28,9 +28,9 @@ use base ('Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf');  # All Hive datab
 
 sub resource_classes {
     my ($self) = @_;
-    return { 'default' => { 'LSF' => '-q production-rh74'},
-         '1GB' => { 'LSF' => '-q production-rh74 -M 1000 -R "rusage[mem=1000]"' },
-         '2GB' => { 'LSF' => '-q production-rh74 -M 2000 -R "rusage[mem=2000]"' } };
+    return { 'default' => { 'LSF' => '-q production'},
+         '1GB' => { 'LSF' => '-q production -M 1000 -R "rusage[mem=1000]"' },
+         '2GB' => { 'LSF' => '-q production -M 2000 -R "rusage[mem=2000]"' } };
 }
 
 sub default_options {

--- a/modules/Bio/EnsEMBL/Utils/MetadataJsonLoader.pm
+++ b/modules/Bio/EnsEMBL/Utils/MetadataJsonLoader.pm
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2020] EMBL-European Bioinformatics Institute
+# Copyright [2016-2021] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/PublicMySQLServer.pm
+++ b/modules/Bio/EnsEMBL/Utils/PublicMySQLServer.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2009-2020] EMBL-European Bioinformatics Institute
+Copyright [2009-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/t/00-load.t
+++ b/modules/t/00-load.t
@@ -1,5 +1,5 @@
 #!perl
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/01-uniq.t
+++ b/modules/t/01-uniq.t
@@ -1,5 +1,5 @@
 #!perl
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/02-load_dbs.t
+++ b/modules/t/02-load_dbs.t
@@ -1,5 +1,5 @@
 #!perl
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/03-parse_dbnames.t
+++ b/modules/t/03-parse_dbnames.t
@@ -1,5 +1,5 @@
 #!perl
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/10-create_genomeinfo.t
+++ b/modules/t/10-create_genomeinfo.t
@@ -1,4 +1,4 @@
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/11-create_comparainfo.t
+++ b/modules/t/11-create_comparainfo.t
@@ -1,4 +1,4 @@
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/12-create_assemblyinfo.t
+++ b/modules/t/12-create_assemblyinfo.t
@@ -1,4 +1,4 @@
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/13-create_organisminfo.t
+++ b/modules/t/13-create_organisminfo.t
@@ -1,4 +1,4 @@
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/14-create_releaseinfo.t
+++ b/modules/t/14-create_releaseinfo.t
@@ -1,4 +1,4 @@
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/15-create_genomeinfo_composed.t
+++ b/modules/t/15-create_genomeinfo_composed.t
@@ -1,4 +1,4 @@
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/16-create_genomeinfo_with_dbs.t
+++ b/modules/t/16-create_genomeinfo_with_dbs.t
@@ -1,4 +1,4 @@
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/17-create_releaseinfo_with_dbs.t
+++ b/modules/t/17-create_releaseinfo_with_dbs.t
@@ -1,4 +1,4 @@
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/20-create_database_events.t
+++ b/modules/t/20-create_database_events.t
@@ -1,4 +1,4 @@
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/21-create_genome_events.t
+++ b/modules/t/21-create_genome_events.t
@@ -1,4 +1,4 @@
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/22-create_compara_events.t
+++ b/modules/t/22-create_compara_events.t
@@ -1,4 +1,4 @@
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/30-analyse_bacteria.t
+++ b/modules/t/30-analyse_bacteria.t
@@ -1,4 +1,4 @@
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/31-analyse_human.t
+++ b/modules/t/31-analyse_human.t
@@ -1,4 +1,4 @@
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/40-lookup_local_bacteria.t
+++ b/modules/t/40-lookup_local_bacteria.t
@@ -1,4 +1,4 @@
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/41-lookup_remote_bacteria.t
+++ b/modules/t/41-lookup_remote_bacteria.t
@@ -1,4 +1,4 @@
-# Copyright [2009-2020] EMBL-European Bioinformatics Institute
+# Copyright [2009-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/populate_test_ncbi_taxonomy.sql
+++ b/modules/t/populate_test_ncbi_taxonomy.sql
@@ -1,4 +1,4 @@
--- Copyright [2009-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2009-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_01022018_a.sql
+++ b/sql/patch_01022018_a.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_01022018_b.sql
+++ b/sql/patch_01022018_b.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_01022019_o.sql
+++ b/sql/patch_01022019_o.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_03012019_n.sql
+++ b/sql/patch_03012019_n.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_03042020_s.sql
+++ b/sql/patch_03042020_s.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_05022019_p.sql
+++ b/sql/patch_05022019_p.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_07022018_c.sql
+++ b/sql/patch_07022018_c.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_07032018_i.sql
+++ b/sql/patch_07032018_i.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_08022018_d.sql
+++ b/sql/patch_08022018_d.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_09022018_e.sql
+++ b/sql/patch_09022018_e.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_09022018_f.sql
+++ b/sql/patch_09022018_f.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_11022020_r.sql
+++ b/sql/patch_11022020_r.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_13022018_g.sql
+++ b/sql/patch_13022018_g.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_13022019_q.sql
+++ b/sql/patch_13022019_q.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_13032018_j.sql
+++ b/sql/patch_13032018_j.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_15022018_h.sql
+++ b/sql/patch_15022018_h.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_18042018_k.sql
+++ b/sql/patch_18042018_k.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_24062020_t.sql
+++ b/sql/patch_24062020_t.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_25092018_l.sql
+++ b/sql/patch_25092018_l.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_26112018_m.sql
+++ b/sql/patch_26112018_m.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_30062020_u.sql
+++ b/sql/patch_30062020_u.sql
@@ -1,5 +1,5 @@
 -- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.


### PR DESCRIPTION
I'm not sure what has happened, but a bunch of commits that are in both release/104 and master branches are not in release/105. For example, the [update](https://github.com/Ensembl/ensembl-metadata/blame/master/modules/Bio/EnsEMBL/MetaData/MetadataUpdater.pm#L416) to include the 'ensembl_autocomplete' db in the list of 'pan ensembl' dbs.

Although there are a lot of files in this PR, most are just annual copyright increments.

It's not conventional for us to update the release branch from master, but in this case I think that's the easiest way to get up to date - it does pull some `master` developments in the release branch, but I do not think these are problematic: one is an enhacement to the report_genomes.pl script, the other is a Codon-related update that is probably useful to have on release/105 anyway.
