### PR TITLE
Updating patterns for 'pan Ensembl' databases

### DIFF
--- a/modules/Bio/EnsEMBL/MetaData/MetadataUpdater.pm
+++ b/modules/Bio/EnsEMBL/MetaData/MetadataUpdater.pm
@@ -413,7 +413,7 @@ sub process_release_database {
 #Check pan division databases like ontology db, ncbi_taxonomy, ensembl_metadata,...
 sub check_pan_databases {
   my ($database_name) = @_;
-  return $database_name =~ m/(ontology|ensembl_metadata|ensembl_website|ncbi_taxonomy|ensembl_accounts|ensembl_archive|ensembl_stable_ids|ensemblgenomes_stable_ids|ensembl_production)/;
+  return $database_name =~ m/(ensembl_accounts|ensembl_archive|ensembl_autocomplete|ensembl_metadata|ensembl_production|ensembl_stable_ids|ncbi_taxonomy|ontology|website)/;
 }
 
 #Subroutine to add or force update a species database


### PR DESCRIPTION
Allow for matching of 'grch37_website', which is the GRCh37 version of 'ensembl_website'. Also ordered alphabetically, so it's easier to see what is matched.