### PR TITLE
Adding new 'website_packed' status for Rapid Release. (#154)

### DIFF
--- a/misc_scripts/website_packed_report.pl
+++ b/misc_scripts/website_packed_report.pl
@@ -1,0 +1,118 @@
+#!/usr/bin/env perl
+# Copyright [2016-2021] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+=head1 DESCRIPTION
+
+This script reports the species that have either been packed or are unpacked
+(the latter is the default, since that is likely to be the commonest use case).
+
+=head1 OPTIONS
+
+=over 8
+
+=item B<-host> <host>
+
+=item B<-port> <port>
+
+=item B<-user> <user>
+
+=item B<-pass[word]> <password>
+
+=item B<-db[name]> <dbname>
+
+Mandatory. Connection details, e.g. $(meta1 details script) -db ensembl_metadata
+
+=item B<-e[nsembl_release]> <ensembl_release>
+
+Ensembl release version
+
+=item B<-s[econdary_release]> <secondary_release>
+
+Ensembl Genomes or Rapid Release version
+
+=item B<-p[acked]> <packed>
+
+Packed status to report: 0 or 1 (default 0)
+
+=back
+
+=cut
+
+use warnings;
+use strict;
+use feature 'say';
+
+use Getopt::Long qw(:config no_ignore_case);
+use Pod::Usage;
+
+use Bio::EnsEMBL::MetaData::DBSQL::MetaDataDBAdaptor;
+
+my ($help,
+    $host, $port, $user, $pass, $dbname,
+    $ensembl_release, $secondary_release, $packed);
+
+GetOptions(
+  "h|help!",             \$help,
+  "host=s",              \$host,
+  "port=i",              \$port,
+  "user=s",              \$user,
+  "password:s",          \$pass,
+  "dbname=s",            \$dbname,
+  "ensembl_release:s",   \$ensembl_release,
+  "secondary_release:s", \$secondary_release,
+  "p|packed:i",          \$packed,
+);
+
+pod2usage(1) if $help;
+
+$packed = 0 unless defined $packed;
+
+my $mdba = Bio::EnsEMBL::MetaData::DBSQL::MetaDataDBAdaptor->new(
+  -host    => $host,
+  -port    => $port,
+  -user    => $user,
+  -pass    => $pass,
+  -dbname  => $dbname,
+  -species => 'multi',
+  -group   => 'metadata',
+);
+
+if (! defined $mdba) {
+  say('Unable to connect to metadata database with given parameters');
+  pod2usage(1);
+}
+
+my $gia = $mdba->get_GenomeInfoAdaptor();
+
+if (defined $secondary_release) {
+  $gia->set_ensembl_genomes_release($secondary_release);
+} elsif (defined $ensembl_release) {
+  $gia->set_ensembl_release($ensembl_release);
+}
+
+my @genomes;
+if ($packed) {
+  @genomes = @{ $gia->fetch_all_with_website_packed() };
+} else {
+  @genomes = @{ $gia->fetch_all_without_website_packed() };
+}
+
+foreach my $genome (sort {$a->name cmp $b->name} @genomes) {
+  say join("\t",
+    $genome->name,
+    $genome->data_release->ensembl_version,
+    $genome->data_release->ensembl_genomes_version,
+  );
+}

--- a/misc_scripts/website_packed_update.pl
+++ b/misc_scripts/website_packed_update.pl
@@ -1,0 +1,116 @@
+#!/usr/bin/env perl
+# Copyright [2016-2021] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+=head1 DESCRIPTION
+
+This script sets the 'packed' status, which is used in web display.
+
+=head1 OPTIONS
+
+=over 8
+
+=item B<-host> <host>
+
+=item B<-port> <port>
+
+=item B<-user> <user>
+
+=item B<-pass[word]> <password>
+
+=item B<-db[name]> <dbname>
+
+Mandatory. Connection details, e.g. $(meta1 details script) -db ensembl_metadata
+
+=item B<-n[ame]> <name>
+
+Mandatory. Production name of the species to update, e.g. choloepus_didactylus_gca015220235v1
+
+=item B<-e[nsembl_release]> <ensembl_release>
+
+Ensembl release version
+
+=item B<-s[econdary_release]> <secondary_release>
+
+Ensembl Genomes or Rapid Release version
+
+=item B<-p[acked]> <packed>
+
+Packed status to set: 0 or 1 (default 1)
+
+=back
+
+=cut
+
+use warnings;
+use strict;
+use feature 'say';
+
+use Getopt::Long qw(:config no_ignore_case);
+use Pod::Usage;
+
+use Bio::EnsEMBL::MetaData::DBSQL::MetaDataDBAdaptor;
+
+my ($help,
+    $host, $port, $user, $pass, $dbname,
+    $name, $ensembl_release, $secondary_release, $packed);
+
+GetOptions(
+  "h|help!",             \$help,
+  "host=s",              \$host,
+  "port=i",              \$port,
+  "user=s",              \$user,
+  "password:s",          \$pass,
+  "dbname=s",            \$dbname,
+  "name=s",              \$name,
+  "ensembl_release:s",   \$ensembl_release,
+  "secondary_release:s", \$secondary_release,
+  "p|packed:i",          \$packed,
+);
+
+pod2usage(1) if $help;
+
+if (! defined $name) {
+  say('-name is a mandatory parameter');
+  pod2usage(1);
+}
+
+$packed = 1 unless defined $packed;
+
+my $mdba = Bio::EnsEMBL::MetaData::DBSQL::MetaDataDBAdaptor->new(
+  -host    => $host,
+  -port    => $port,
+  -user    => $user,
+  -pass    => $pass,
+  -dbname  => $dbname,
+  -species => 'multi',
+  -group   => 'metadata',
+);
+
+if (! defined $mdba) {
+  say('Unable to connect to metadata database with given parameters');
+  pod2usage(1);
+}
+
+my $gia  = $mdba->get_GenomeInfoAdaptor();
+
+if (defined $secondary_release) {
+  $gia->set_ensembl_genomes_release($secondary_release);
+} elsif (defined $ensembl_release) {
+  $gia->set_ensembl_release($ensembl_release);
+}
+
+foreach ( @{ $gia->fetch_by_name($name) } ) {
+  $gia->update_website_packed($_, $packed);
+}

--- a/modules/Bio/EnsEMBL/MetaData/GenomeInfo.pm
+++ b/modules/Bio/EnsEMBL/MetaData/GenomeInfo.pm
@@ -846,6 +846,23 @@ sub has_other_alignments {
     return $self->{has_other_alignments} || 0;
 }
 
+=head2 website_packed
+  Arg        : (optional) 1/0 to set if genome has been packed for web display 
+  Description: Boolean-style method, returns 1 if genome has been packed, 0 if not
+  Returntype : 1 or 0
+  Exceptions : none
+  Caller     : general
+  Status     : Stable
+=cut
+
+sub website_packed {
+  my ( $self, $arg ) = @_;
+  if ( defined $arg ) {
+    $self->{website_packed} = $arg;
+  }
+  return $self->{website_packed} || 0;
+}
+
 =head2 count_variation
   Description: Returns total number of variations and structural variations mapped to genome
   Returntype : integer

--- a/modules/t/test-genome-DBs/multi/empty_metadata/table.sql
+++ b/modules/t/test-genome-DBs/multi/empty_metadata/table.sql
@@ -192,6 +192,7 @@ CREATE TABLE `genome` (
   `has_genome_alignments` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `has_synteny` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `has_other_alignments` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `website_packed` tinyint(3) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`genome_id`),
   UNIQUE KEY `release_genome_division` (`data_release_id`,`genome_id`,`division_id`),
   KEY `genome_ibfk_1` (`assembly_id`),

--- a/sql/patch_07072021_v.sql
+++ b/sql/patch_07072021_v.sql
@@ -1,0 +1,22 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
+-- 
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+-- 
+--      http://www.apache.org/licenses/LICENSE-2.0
+-- 
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+# patch_07072021_v
+#
+# Title: Add website_packed column
+#
+# Description: Include a flag to indicate whether a species has been
+#              packed, for display on the website.
+# 
+ALTER TABLE genome ADD COLUMN `website_packed` tinyint(3) unsigned NOT NULL DEFAULT '0';

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -192,6 +192,7 @@ CREATE TABLE `genome` (
   `has_genome_alignments` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `has_synteny` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `has_other_alignments` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `website_packed` tinyint(3) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`genome_id`),
   UNIQUE KEY `release_genome_division` (`data_release_id`,`genome_id`,`division_id`),
   KEY `genome_ibfk_1` (`assembly_id`),


### PR DESCRIPTION
* Adding new 'website_packed' status for Rapid Release.

"Packing" the data for a species, to enable the website display
to be quicker, is generally required whenever a database changes.
Packing can be a time-consuming process, however, so for Rapid
Release, where we have a two-week release cycle and lots of
databases that aren't changing from one release to the next,
we want to avoid redundant work.

This is achieved by means of a new column in the genome table
of the metadata database, 'website_packed'. This defaults to
zero, but once a species has been packed, a script is run,
'website_packed_update.pl', to set it to 1. A companion script,
'website_packed_report.pl', lists the species which either are,
or are not, packed.

Integrating this new column into the metadata updater code is
complicated, and I'm loath to do development when there is a
new metadata schema and process in the offing. Instead, we can
have a new step at the start of a RR release cycle, which sets
the packed value to 1 for existing species.