### PR TITLE
Update ftp links to https

### DIFF
--- a/misc_scripts/report_genomes.pl
+++ b/misc_scripts/report_genomes.pl
@@ -444,10 +444,10 @@ sub write_output_to_file {
     my $news = '';
     my $url;
     if ($division eq "vertebrates") {
-        $url = "ftp://ftp.ensembl.org/pub/release-" . $release . "/"
+        $url = "https://ftp.ensembl.org/pub/release-" . $release . "/"
     }
     else {
-        $url = "ftp://ftp.ensemblgenomes.org/pub/release-" . $release . "/$division/";
+        $url = "https://ftp.ensemblgenomes.org/pub/release-" . $release . "/$division/";
     }
 
     if ($division eq 'bacteria') {

--- a/modules/Bio/EnsEMBL/MetaData/AnnotationAnalyzer.pm
+++ b/modules/Bio/EnsEMBL/MetaData/AnnotationAnalyzer.pm
@@ -255,7 +255,7 @@ sub analyze_tracks {
 # [1_Puccinia_triticina_SRR035315]
 # source_name        = Transcriptomics sequences of fresh spores. Run id: SRR035315
 # description        = RNA-Seq study.
-# source_url         = http://ftp.sra.ebi.ac.uk/vol1/ERZ000/ERZ000002/SRR035315.bam
+# source_url         = https://ftp.sra.ebi.ac.uk/vol1/ERZ000/ERZ000002/SRR035315.bam
 # source_type        = rnaseq
 # display            = normal
 # then store some or all of this in my output e.g. {bam}{source_type}[{source_name,description,source_url}]

--- a/modules/Bio/EnsEMBL/MetaData/MetaDataDumper/TT2MetaDataDumper.pm
+++ b/modules/Bio/EnsEMBL/MetaData/MetaDataDumper/TT2MetaDataDumper.pm
@@ -100,7 +100,7 @@ sub do_dump {
 </script> 
 <div id="static">
 <h2>Ensembl Genomes Release $eg_version</h2>
-<p>Ensembl Genomes species metadata are also available via FTP: <a href="ftp://ftp.ensemblgenomes.org/pub/current/species.txt">Tabular text</a> | <a href="ftp://ftp.ensemblgenomes.org/pub/current/species_metadata.json">JSON</a> | <a href="ftp://ftp.ensemblgenomes.org/pub/current/species_metadata.xml">XML</a></p> 
+<p>Ensembl Genomes species metadata are also available via FTP: <a href="https://ftp.ensemblgenomes.org/pub/current/species.txt">Tabular text</a> | <a href="https://ftp.ensemblgenomes.org/pub/current/species_metadata.json">JSON</a> | <a href="https://ftp.ensemblgenomes.org/pub/current/species_metadata.xml">XML</a></p> 
 <table cellpadding="0" cellspacing="0" border="1px dotted #eeeeee"
 class="display" id="species_list">
 <thead> 


### PR DESCRIPTION
This PR updates all ftp URLs to use https (to be compatible with web browsers).
The affected hostnames have been tested working with https.
Similar PRs in other repos are listed in the JIRA ticket.

Webteam JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6632
Sandbox: http://wp-np2-1d.ebi.ac.uk:1680/