### PR TITLE
fix for trailing tab in metadata dump  species_EnsemblVertebrates.txt

### DIFF
--- a/modules/Bio/EnsEMBL/MetaData/MetaDataDumper/TextMetaDataDumper.pm
+++ b/modules/Bio/EnsEMBL/MetaData/MetaDataDumper/TextMetaDataDumper.pm
@@ -89,8 +89,10 @@ sub _write_metadata_to_file {
 				  $self->yesno($md->has_genome_alignments()),
 				  $self->yesno($md->has_other_alignments()),
 				  $md->dbname(),
-				  $md->species_id(),
-				  "\n"));
+				  $md->species_id()
+				  ));
+
+	print $fh "\n";
   return;
 }
 


### PR DESCRIPTION
Fix for inconsistent tab space in the header and data  for  metadata dump  species_EnsemblVertebrates.txt file 